### PR TITLE
Fix "Cannot create a handle without a HandleScope" in AsyncReadFileAfter()

### DIFF
--- a/src/taglib.cc
+++ b/src/taglib.cc
@@ -245,6 +245,7 @@ void AsyncReadFileAfter(uv_work_t *req) {
             tagObj->Set(Nan::New("artist").ToLocalChecked(), TagLibStringToString(tag->artist()));
             tagObj->Set(Nan::New("comment").ToLocalChecked(), TagLibStringToString(tag->comment()));
             tagObj->Set(Nan::New("genre").ToLocalChecked(), TagLibStringToString(tag->genre()));
+            tagObj->Set(Nan::New("path").ToLocalChecked(), TagLibStringToString(baton->path));
             tagObj->Set(Nan::New("title").ToLocalChecked(), TagLibStringToString(tag->title()));
             tagObj->Set(Nan::New("track").ToLocalChecked(), Nan::New(tag->track()));
             tagObj->Set(Nan::New("year").ToLocalChecked(), Nan::New(tag->year()));

--- a/src/taglib.cc
+++ b/src/taglib.cc
@@ -228,6 +228,7 @@ void AsyncReadFileDo(uv_work_t *req) {
 
 void AsyncReadFileAfter(uv_work_t *req) {
     AsyncBaton *baton = static_cast<AsyncBaton*>(req->data);
+    Nan::HandleScope scope;
     if (baton->error) {
         Local<Object> error = Nan::New<Object>();
         error->Set(Nan::New("code").ToLocalChecked(), Nan::New(baton->error));


### PR DESCRIPTION
Fixes a fatal v8 error:

```
$ node example/simple.js test.mp3
FATAL ERROR: v8::HandleScope::CreateHandle() Cannot create a handle without a HandleScope
Abandon
```

See https://github.com/nodejs/nan/issues/440

**Tested (node 4.4.2):**
- Open file and read tag asynchronously

**Untested (and probably should be tested!):**
- Open file and read tag synchronously
- Edit and save tag
